### PR TITLE
[FEAT] 로그인, 로그아웃, 토큰 재발급

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -33,6 +33,7 @@ jobs:
           spring.datasource.url: ${{ secrets.SPRING_DATASOURCE_URL }}
           spring.datasource.username: ${{ secrets.SPRING_DATASOURCE_USERNAME }}
           spring.datasource.password: ${{ secrets.SPRING_DATASOURCE_PASSWORD }}
+          kakao.client-id: ${{secrets.KAKAO_CLIENT_ID}}
 
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -33,6 +33,11 @@ jobs:
           spring.datasource.url: ${{ secrets.SPRING_DATASOURCE_URL }}
           spring.datasource.username: ${{ secrets.SPRING_DATASOURCE_USERNAME }}
           spring.datasource.password: ${{ secrets.SPRING_DATASOURCE_PASSWORD }}
+          jwt.secret: ${{ secrets.JWT_SECRET }}
+          login.uri: ${{ secrets.LOGIN_URI }}
+          kakao.client-id: ${{ secrets.KAKAO_CLIENT_ID }}
+          kakao.client-secret: ${{ secrets.KAKAO_CLIENT_SECRET }}
+          kakao.redirect-uri: ${{ secrets.KAKAO_REDIRECT_URI }}
 
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  S3_BUCKET_NAME: wepro
+  S3_BUCKET_NAME: wepro1
   RESOURCE_PATH: ./src/main/resources/application.yaml
   CODE_DEPLOY_APPLICATION_NAME: wepro-code-deploy
   CODE_DEPLOY_DEPLOYMENT_GROUP_NAME: wepro-server
@@ -15,6 +15,20 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.0
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_ROOT_PASSWORD: ${{ secrets.SPRING_DATASOURCE_PASSWORD }}
+          MYSQL_DATABASE: wepro
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
 
     steps:
       - name: Checkout
@@ -42,6 +56,13 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
         shell: bash
+
+      - name: Wait for MySQL
+        run: |
+            while ! mysqladmin ping -h"127.0.0.1" --silent; do
+              echo "Waiting for MySQL to be ready..."
+              sleep 1
+            done
 
       - name: Build with Gradle
         run: ./gradlew build

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,22 @@ dependencies {
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // feign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation platform("org.springframework.cloud:spring-cloud-dependencies:2023.0.2")
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -18,3 +18,12 @@ services:
       - ${DEFAULT_PATH}/mysql/data:/var/lib/mysql
       - ${DEFAULT_PATH}/mysql/initdb.d:/docker-entrypoint-initdb.d
     restart: always
+  redis:
+    container_name: "redis"
+    image: redis:latest
+    command: redis-server --port 6379
+    ports:
+      - "6379:6379"
+    volumes:
+      - ${DEFAULT_PATH}/redis/data:/data
+    restart: always

--- a/src/main/java/com/_119/wepro/auth/client/KakaoOauthClient.java
+++ b/src/main/java/com/_119/wepro/auth/client/KakaoOauthClient.java
@@ -2,7 +2,6 @@ package com._119.wepro.auth.client;
 
 import com._119.wepro.auth.dto.response.KakaoTokenResponse;
 import com._119.wepro.auth.dto.response.OIDCPublicKeyResponse;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -23,8 +22,8 @@ public interface KakaoOauthClient {
       @PathVariable("CODE") String code,
       @PathVariable("CLIENT_SECRET") String client_secret);
 
-  // oidc 공개 키 받아 오기
-  @Cacheable(cacheNames = "KakaoOICD", cacheManager = "oidcCacheManager") // 공개키 자주 요청할 거 같으면, 캐싱하기
+  // oidc 공개 키 받아 오기 - 안 쓸 예정
+//  @Cacheable(cacheNames = "KakaoOICD", cacheManager = "oidcCacheManager") // 공개키 자주 요청할 거 같으면, 캐싱하기
   @GetMapping("/.well-known/jwks.json")
   OIDCPublicKeyResponse getOIDCPublicKey();
 }

--- a/src/main/java/com/_119/wepro/auth/client/KakaoOauthClient.java
+++ b/src/main/java/com/_119/wepro/auth/client/KakaoOauthClient.java
@@ -1,0 +1,30 @@
+package com._119.wepro.auth.client;
+
+import com._119.wepro.auth.dto.response.KakaoTokenResponse;
+import com._119.wepro.auth.dto.response.OIDCPublicKeyResponse;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@FeignClient(
+    name = "KakaoOauthClient",
+    url = "https://kauth.kakao.com"
+)
+public interface KakaoOauthClient {
+
+  // 만약 클라이언트로부터 code 받을 경우,
+  @PostMapping(
+      "/oauth/token?grant_type=authorization_code&client_id={CLIENT_ID}&redirect_uri={REDIRECT_URI}&code={CODE}&client_secret={CLIENT_SECRET}")
+  KakaoTokenResponse kakaoAuth(
+      @PathVariable("CLIENT_ID") String clientId,
+      @PathVariable("REDIRECT_URI") String redirectUri,
+      @PathVariable("CODE") String code,
+      @PathVariable("CLIENT_SECRET") String client_secret);
+
+  // oidc 공개 키 받아 오기
+  @Cacheable(cacheNames = "KakaoOICD", cacheManager = "oidcCacheManager") // 공개키 자주 요청할 거 같으면, 캐싱하기
+  @GetMapping("/.well-known/jwks.json")
+  OIDCPublicKeyResponse getOIDCPublicKey();
+}

--- a/src/main/java/com/_119/wepro/auth/dto/request/AuthRequest.java
+++ b/src/main/java/com/_119/wepro/auth/dto/request/AuthRequest.java
@@ -29,6 +29,18 @@ public class AuthRequest {
   @Builder
   @NoArgsConstructor
   @AllArgsConstructor
+  public static class RefreshRequest {
+    @NotNull
+    private String accessToken;
+
+    @NotNull
+    private String refreshToken;
+  }
+
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class SignUpRequest {
 
     @NotNull

--- a/src/main/java/com/_119/wepro/auth/dto/request/AuthRequest.java
+++ b/src/main/java/com/_119/wepro/auth/dto/request/AuthRequest.java
@@ -1,0 +1,37 @@
+package com._119.wepro.auth.dto.request;
+
+import com._119.wepro.global.enums.Provider;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class AuthRequest {
+
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class SignInRequest {
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private Provider provider;
+
+    @NotNull
+    private String idToken;
+  }
+
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class SignUpRequest {
+
+    @NotNull
+    private String position;
+  }
+}

--- a/src/main/java/com/_119/wepro/auth/dto/response/AuthResponse.java
+++ b/src/main/java/com/_119/wepro/auth/dto/response/AuthResponse.java
@@ -2,13 +2,11 @@ package com._119.wepro.auth.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 public class AuthResponse {
 
   @Getter
   @AllArgsConstructor
-  @NoArgsConstructor
   public static class SignInResponse {
 
     private boolean newMember;

--- a/src/main/java/com/_119/wepro/auth/dto/response/AuthResponse.java
+++ b/src/main/java/com/_119/wepro/auth/dto/response/AuthResponse.java
@@ -1,0 +1,18 @@
+package com._119.wepro.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class AuthResponse {
+
+  @Getter
+  @AllArgsConstructor
+  @NoArgsConstructor
+  public static class SignInResponse {
+
+    private boolean newMember;
+    private TokenInfo tokenInfo;
+  }
+
+}

--- a/src/main/java/com/_119/wepro/auth/dto/response/KakaoTokenResponse.java
+++ b/src/main/java/com/_119/wepro/auth/dto/response/KakaoTokenResponse.java
@@ -1,0 +1,15 @@
+package com._119.wepro.auth.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonNaming(SnakeCaseStrategy.class)
+public class KakaoTokenResponse {
+  private String accessToken;
+  private String refreshToken;
+  private String idToken;
+}

--- a/src/main/java/com/_119/wepro/auth/dto/response/OIDCPublicKeyResponse.java
+++ b/src/main/java/com/_119/wepro/auth/dto/response/OIDCPublicKeyResponse.java
@@ -1,0 +1,23 @@
+package com._119.wepro.auth.dto.response;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OIDCPublicKeyResponse {
+
+  private List<OIDCPublicKey> keys;
+
+  @Getter
+  @NoArgsConstructor
+  public static class OIDCPublicKey {
+
+    private String kid;
+    private String alg;
+    private String use;
+    private String n;
+    private String e;
+  }
+}

--- a/src/main/java/com/_119/wepro/auth/dto/response/TokenInfo.java
+++ b/src/main/java/com/_119/wepro/auth/dto/response/TokenInfo.java
@@ -1,0 +1,12 @@
+package com._119.wepro.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenInfo {
+  private String type;
+  private String accessToken;
+  private String refreshToken;
+}

--- a/src/main/java/com/_119/wepro/auth/jwt/JwtTokenExceptionFilter.java
+++ b/src/main/java/com/_119/wepro/auth/jwt/JwtTokenExceptionFilter.java
@@ -1,0 +1,50 @@
+package com._119.wepro.auth.jwt;
+
+import com._119.wepro.global.dto.ErrorResponseDto;
+import com._119.wepro.global.exception.RestApiException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+public class JwtTokenExceptionFilter extends OncePerRequestFilter {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    try {
+      filterChain.doFilter(request, response);
+    } catch (RestApiException e) {
+      logClientIpAndRequestUri(request);
+      sendErrorResponse(response, e);
+    }
+  }
+
+  private void logClientIpAndRequestUri(HttpServletRequest request) {
+    String clientIp = request.getHeader("X-Forwarded-For");
+    if (clientIp == null) {
+      clientIp = request.getRemoteAddr();
+    }
+    log.error("Invalid token for requestURI: {}, Access from IP: {}", request.getRequestURI(),
+        clientIp);
+  }
+
+  private void sendErrorResponse(HttpServletResponse response, RestApiException e)
+      throws IOException {
+    ErrorResponseDto errorResponseDto = ErrorResponseDto.builder()
+        .code(e.getErrorCode().name())
+        .message(e.getErrorCode().getMessage())
+        .build();
+
+    response.setStatus(e.getErrorCode().getHttpStatus().value());
+    response.setContentType("application/json;charset=UTF-8");
+    response.getWriter().write(objectMapper.writeValueAsString(errorResponseDto));
+  }
+}

--- a/src/main/java/com/_119/wepro/auth/jwt/JwtTokenFilter.java
+++ b/src/main/java/com/_119/wepro/auth/jwt/JwtTokenFilter.java
@@ -1,0 +1,62 @@
+package com._119.wepro.auth.jwt;
+
+import static com._119.wepro.global.exception.errorcode.CommonErrorCode.NOT_EXIST_BEARER_SUFFIX;
+
+import com._119.wepro.global.exception.RestApiException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtTokenFilter extends OncePerRequestFilter {
+
+  private final JwtTokenProvider jwtTokenProvider;
+  private final String accessHeader = "Authorization";
+  private final String grantType = "Bearer";
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+
+    Optional<String> token = getTokensFromHeader(request, accessHeader);
+
+    token.ifPresent(t -> {
+      String accessToken = getAccessToken(t);
+
+      Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+    });
+
+    String clientIp = request.getHeader("X-Forwarded-For");
+    if (clientIp == null) {
+      clientIp = request.getRemoteAddr();
+    }
+    log.error("Invalid token for requestURI: {}, Access from IP: {}", request.getRequestURI(), clientIp);
+
+    filterChain.doFilter(request, response);
+  }
+
+  private Optional<String> getTokensFromHeader(HttpServletRequest request, String header) {
+    return Optional.ofNullable(request.getHeader(header));
+  }
+
+  private String getAccessToken(String token) {
+    String suffix = grantType + " ";
+
+    if (!token.startsWith(suffix)) {
+      throw new RestApiException(NOT_EXIST_BEARER_SUFFIX);
+    }
+
+    return token.replace(suffix, "");
+  }
+}

--- a/src/main/java/com/_119/wepro/auth/jwt/JwtTokenFilter.java
+++ b/src/main/java/com/_119/wepro/auth/jwt/JwtTokenFilter.java
@@ -36,13 +36,6 @@ public class JwtTokenFilter extends OncePerRequestFilter {
 
       SecurityContextHolder.getContext().setAuthentication(authentication);
     });
-
-    String clientIp = request.getHeader("X-Forwarded-For");
-    if (clientIp == null) {
-      clientIp = request.getRemoteAddr();
-    }
-    log.error("Invalid token for requestURI: {}, Access from IP: {}", request.getRequestURI(), clientIp);
-
     filterChain.doFilter(request, response);
   }
 

--- a/src/main/java/com/_119/wepro/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/_119/wepro/auth/jwt/JwtTokenProvider.java
@@ -31,7 +31,7 @@ import org.springframework.util.StringUtils;
 @Component
 public class JwtTokenProvider {
 
-  private static final long ACCESS_TOKEN_DURATION = 1000 * 60 * 60L * 24 * 7; // 1일
+  private static final long ACCESS_TOKEN_DURATION = 1000 * 60 * 60L * 24; // 1일
   private static final long REFRESH_TOKEN_DURATION = 1000 * 60 * 60L * 24 * 7; // 7일
   private static final String AUTHORITIES_KEY = "auth";
   private final RedisUtil redisUtil;

--- a/src/main/java/com/_119/wepro/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/_119/wepro/auth/jwt/JwtTokenProvider.java
@@ -1,0 +1,138 @@
+package com._119.wepro.auth.jwt;
+
+import static com._119.wepro.global.exception.errorcode.CommonErrorCode.EXPIRED_TOKEN;
+import static com._119.wepro.global.exception.errorcode.CommonErrorCode.INVALID_TOKEN;
+
+import com._119.wepro.auth.dto.response.TokenInfo;
+import com._119.wepro.global.enums.Role;
+import com._119.wepro.global.exception.RestApiException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class JwtTokenProvider {
+
+  private static final long ACCESS_TOKEN_DURATION = 1000 * 60 * 60L * 24; // 1일
+  private static final long REFRESH_TOKEN_DURATION = 1000 * 60 * 60L * 24 * 7; // 7일
+
+  private SecretKey secretKey;
+
+  public JwtTokenProvider(@Value("${jwt.secret}") String key) {
+    byte[] keyBytes = key.getBytes();
+    this.secretKey = Keys.hmacShaKeyFor(keyBytes);
+  }
+
+  public TokenInfo generateToken(Long memberId, Role memberRole) {
+    String accessToken = generateAccessToken(memberId, memberRole);
+    // TODO: refresh redis에 저장
+    String refreshToken = generateRefreshToken();
+
+    return new TokenInfo("Bearer", accessToken, refreshToken);
+  }
+
+  public boolean validateToken(String token) {
+    if (!StringUtils.hasText(token)) {
+      return false;
+    }
+
+    Claims claims = parseClaims(token);
+    return claims.getExpiration().after(new Date());
+  }
+
+
+  public Authentication getAuthentication(String accessToken) {
+    Claims claims = parseClaims(accessToken);
+
+    if (claims.get("auth") == null) {
+      throw new RestApiException(INVALID_TOKEN);
+    }
+    List<SimpleGrantedAuthority> authority = getAuthorities(claims);
+    validateAuthorityValue(authority);
+
+    UserDetails principal = new User(claims.getSubject(), "", authority);
+    return new UsernamePasswordAuthenticationToken(principal, "", authority);
+  }
+
+  private void validateAuthorityValue(List<SimpleGrantedAuthority> authority) {
+    if (authority.size() != 1
+        || !isValidAuthority(authority.get(0))) {
+      throw new RestApiException(INVALID_TOKEN);
+    }
+  }
+
+  private boolean isValidAuthority(SimpleGrantedAuthority authority) {
+    for (Role role : Role.values()) {
+      if (role.name().equals(authority.getAuthority())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private Claims parseClaims(String accessToken) {
+    try {
+      // TODO: 블랙 리스트 여부 추가
+      return Jwts.parserBuilder()
+          .setSigningKey(secretKey)
+          .build()
+          .parseClaimsJws(accessToken)
+          .getBody();
+    } catch (SecurityException | MalformedJwtException e) {
+      throw new RestApiException(INVALID_TOKEN);
+    } catch (ExpiredJwtException e) {
+      throw new RestApiException(EXPIRED_TOKEN);
+    } catch (UnsupportedJwtException e) {
+      throw new RestApiException(INVALID_TOKEN);
+    } catch (IllegalArgumentException e) {
+      throw new RestApiException(INVALID_TOKEN);
+    } catch (JwtException e) {
+      throw new RestApiException(INVALID_TOKEN);
+    }
+  }
+
+  private String generateAccessToken(Long memberId, Role memberRole) {
+    Date now = new Date();
+    Date expiredDate = new Date(now.getTime() + ACCESS_TOKEN_DURATION);
+
+    return Jwts.builder()
+        .setSubject(memberId.toString())
+        .claim("auth", memberRole.name())
+        .setIssuedAt(now)
+        .setExpiration(expiredDate)
+        .signWith(secretKey, SignatureAlgorithm.HS256)
+        .compact();
+  }
+
+  private String generateRefreshToken() {
+    Date now = new Date();
+    Date expiredDate = new Date(now.getTime() + REFRESH_TOKEN_DURATION);
+
+    return Jwts.builder()
+        .setExpiration(expiredDate)
+        .signWith(secretKey, SignatureAlgorithm.HS256)
+        .compact();
+  }
+
+  private List<SimpleGrantedAuthority> getAuthorities(Claims claims) {
+    return Collections.singletonList(new SimpleGrantedAuthority(
+        claims.get("auth").toString()));
+  }
+}

--- a/src/main/java/com/_119/wepro/auth/presentation/AuthController.java
+++ b/src/main/java/com/_119/wepro/auth/presentation/AuthController.java
@@ -1,0 +1,58 @@
+package com._119.wepro.auth.presentation;
+
+import com._119.wepro.auth.dto.response.AuthResponse.SignInResponse;
+import com._119.wepro.auth.service.KakaoService;
+import com._119.wepro.auth.service.SignInService;
+import com._119.wepro.auth.dto.request.AuthRequest.*;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.view.RedirectView;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+public class AuthController {
+
+  private final KakaoService kakaoService;
+  private final SignInService signInService;
+
+  @PostMapping("/login")
+  @Operation(summary = "Kakao idToken 받아 소셜 로그인")
+  public ResponseEntity<SignInResponse> signIn(
+      @RequestBody @Valid SignInRequest request) {
+    return ResponseEntity.ok(signInService.signIn(request));
+  }
+
+  @PostMapping("/signup")
+  @Operation(summary = "직군 정보 받아 최종 회원가입")
+  public ResponseEntity<Void> register(
+      @RequestBody @Valid SignUpRequest request) {
+    return ResponseEntity.ok().build();
+  }
+
+  @GetMapping("/auth/kakao")
+  @Operation(summary = "Kakao Web 소셜 로그인 용 api, 백엔드용")
+  public RedirectView kakaoLogin() {
+    return new RedirectView(kakaoService.generateKakaoRedirectUrl());
+  }
+
+  @GetMapping("/login/oauth2/code/kakao")
+  @Operation(summary = "카카오 code 받는 api, 백엔드용")
+  public SignInResponse handleKakaoCallback(@RequestParam String code) {
+    return kakaoService.handleKakaoCallback(code);
+  }
+
+  @GetMapping("/test")
+  public void test(Authentication authentication) {
+    log.info(authentication.getName());
+  }
+}

--- a/src/main/java/com/_119/wepro/auth/presentation/AuthController.java
+++ b/src/main/java/com/_119/wepro/auth/presentation/AuthController.java
@@ -1,8 +1,10 @@
 package com._119.wepro.auth.presentation;
 
 import com._119.wepro.auth.dto.response.AuthResponse.SignInResponse;
+import com._119.wepro.auth.dto.response.TokenInfo;
 import com._119.wepro.auth.service.KakaoService;
-import com._119.wepro.auth.service.SignInService;
+import com._119.wepro.auth.service.RefreshService;
+import com._119.wepro.auth.service.AuthService;
 import com._119.wepro.auth.dto.request.AuthRequest.*;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -23,13 +25,28 @@ import org.springframework.web.servlet.view.RedirectView;
 public class AuthController {
 
   private final KakaoService kakaoService;
-  private final SignInService signInService;
+  private final AuthService authService;
+  private final RefreshService refreshService;
 
   @PostMapping("/login")
   @Operation(summary = "Kakao idToken 받아 소셜 로그인")
   public ResponseEntity<SignInResponse> signIn(
       @RequestBody @Valid SignInRequest request) {
-    return ResponseEntity.ok(signInService.signIn(request));
+    return ResponseEntity.ok(authService.signIn(request));
+  }
+
+  @PostMapping("/refresh")
+  @Operation(summary = "access token 재발급")
+  public ResponseEntity<TokenInfo> refresh(
+      @RequestBody @Valid RefreshRequest request) {
+    return ResponseEntity.ok(refreshService.refresh(request));
+  }
+
+  @PostMapping("/logout")
+  @Operation(summary = "로그아웃")
+  public ResponseEntity<Void> logout(Authentication authentication){
+    authService.logOut(authentication.getName());
+    return ResponseEntity.ok().build();
   }
 
   @PostMapping("/signup")

--- a/src/main/java/com/_119/wepro/auth/service/AuthService.java
+++ b/src/main/java/com/_119/wepro/auth/service/AuthService.java
@@ -46,15 +46,15 @@ public class AuthService {
     OidcUser oidcDecodePayload = socialLogin(request);
 
     Member member = getOrSaveUser(request, oidcDecodePayload);
-    TokenInfo tokenInfo = jwtTokenProvider.generateToken(member.getId(), member.getRole());
+    TokenInfo tokenInfo = jwtTokenProvider.generateToken(member.getProviderId(), member.getRole());
     boolean isNewMember = Role.GUEST == member.getRole();
 
     return new SignInResponse(isNewMember, tokenInfo);
   }
 
   @Transactional
-  public void logOut(String memberId) {
-    jwtTokenProvider.deleteInvalidRefreshToken(memberId);
+  public void logOut(String providerId) {
+    jwtTokenProvider.deleteInvalidRefreshToken(providerId);
   }
 
 

--- a/src/main/java/com/_119/wepro/auth/service/AuthService.java
+++ b/src/main/java/com/_119/wepro/auth/service/AuthService.java
@@ -3,32 +3,32 @@ package com._119.wepro.auth.service;
 import static com._119.wepro.global.enums.Provider.APPLE;
 import static com._119.wepro.global.enums.Provider.KAKAO;
 
+import com._119.wepro.auth.dto.request.AuthRequest.SignInRequest;
 import com._119.wepro.auth.dto.response.AuthResponse.SignInResponse;
 import com._119.wepro.auth.dto.response.TokenInfo;
+import com._119.wepro.auth.jwt.JwtTokenProvider;
 import com._119.wepro.global.enums.Provider;
 import com._119.wepro.global.enums.Role;
-import com._119.wepro.auth.jwt.JwtTokenProvider;
 import com._119.wepro.member.domain.Member;
 import com._119.wepro.member.domain.repository.MemberRepository;
-import com._119.wepro.auth.dto.request.AuthRequest.SignInRequest;
 import jakarta.transaction.Transactional;
 import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.stereotype.Service;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
-import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.stereotype.Service;
 
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class SignInService {
+public class AuthService {
 
   private final MemberRepository memberRepository;
   private final JwtTokenProvider jwtTokenProvider;
@@ -50,6 +50,11 @@ public class SignInService {
     boolean isNewMember = Role.GUEST == member.getRole();
 
     return new SignInResponse(isNewMember, tokenInfo);
+  }
+
+  @Transactional
+  public void logOut(String memberId) {
+    jwtTokenProvider.deleteInvalidRefreshToken(memberId);
   }
 
 

--- a/src/main/java/com/_119/wepro/auth/service/KakaoService.java
+++ b/src/main/java/com/_119/wepro/auth/service/KakaoService.java
@@ -1,0 +1,73 @@
+package com._119.wepro.auth.service;
+
+import com._119.wepro.auth.dto.request.AuthRequest.SignInRequest;
+import com._119.wepro.auth.dto.response.AuthResponse.SignInResponse;
+import com._119.wepro.global.enums.Provider;
+import com._119.wepro.auth.client.KakaoOauthClient;
+import com._119.wepro.auth.dto.response.KakaoTokenResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoService {
+
+  private final KakaoOauthClient kakaoOauthClient;
+
+  // 임시
+  private static final String LOGIN_URI = "http://localhost:8080/login";
+
+  @Value("${kakao.client-id}")
+  private String CLIENT_ID;
+
+  @Value("${kakao.redirect-uri}")
+  private String REDIRECT_URI;
+
+  @Value("${kakao.client-secret}")
+  private String CLIENT_SECRET;
+
+  @Value("${kakao.authorization-uri}")
+  private String KAKAO_AUTH_URL;
+
+  // 백엔드용
+  public String generateKakaoRedirectUrl() {
+    return UriComponentsBuilder.fromUriString(KAKAO_AUTH_URL)
+        .queryParam("client_id", CLIENT_ID)
+        .queryParam("redirect_uri", REDIRECT_URI)
+        .queryParam("response_type", "code")
+        .build()
+        .toUriString();
+  }
+
+  // 백엔드용
+  public SignInResponse handleKakaoCallback(String code) {
+    KakaoTokenResponse tokenResponse = kakaoOauthClient.kakaoAuth(CLIENT_ID, REDIRECT_URI, code,
+        CLIENT_SECRET);
+    String idToken = tokenResponse.getIdToken();
+    ResponseEntity<SignInResponse> response = callLoginApiWithIdToken(idToken);
+
+    return response.getBody();
+  }
+
+  // 백엔드용
+  private ResponseEntity<SignInResponse> callLoginApiWithIdToken(String idToken) {
+    RestTemplate restTemplate = new RestTemplate();
+    SignInRequest signInRequest = new SignInRequest(Provider.KAKAO, idToken);
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    HttpEntity<SignInRequest> requestEntity = new HttpEntity<>(signInRequest, headers);
+
+    ResponseEntity<SignInResponse> response = restTemplate.postForEntity(LOGIN_URI, requestEntity,
+        SignInResponse.class);
+
+    return response;
+  }
+}

--- a/src/main/java/com/_119/wepro/auth/service/KakaoService.java
+++ b/src/main/java/com/_119/wepro/auth/service/KakaoService.java
@@ -21,8 +21,8 @@ public class KakaoService {
 
   private final KakaoOauthClient kakaoOauthClient;
 
-  // 임시
-  private static final String LOGIN_URI = "http://localhost:8080/login";
+  @Value("${login.uri}")
+  private String LOGIN_URI;
 
   @Value("${kakao.client-id}")
   private String CLIENT_ID;

--- a/src/main/java/com/_119/wepro/auth/service/RefreshService.java
+++ b/src/main/java/com/_119/wepro/auth/service/RefreshService.java
@@ -30,13 +30,14 @@ public class RefreshService {
     if (!isTokenExpired(accessToken)) {
       throw new RestApiException(REFRESH_DENIED);
     }
-    String memberId = jwtTokenProvider.parseExpiredToken(accessToken)
+    String providerId = jwtTokenProvider.parseExpiredToken(accessToken)
         .getSubject();
-    Member member = memberRepository.findById(Long.parseLong(memberId))
+    validateRefreshToken(refreshToken, providerId);
+
+    Member member = memberRepository.findByProviderId(providerId)
         .orElseThrow(() -> new RestApiException(UserErrorCode.USER_NOT_FOUND));
 
-    validateRefreshToken(refreshToken, memberId);
-    return jwtTokenProvider.generateToken(Long.parseLong(memberId), member.getRole());
+    return jwtTokenProvider.generateToken(providerId, member.getRole());
   }
 
   private boolean isTokenExpired(String accessToken) {

--- a/src/main/java/com/_119/wepro/auth/service/RefreshService.java
+++ b/src/main/java/com/_119/wepro/auth/service/RefreshService.java
@@ -1,0 +1,60 @@
+package com._119.wepro.auth.service;
+
+import static com._119.wepro.global.exception.errorcode.CommonErrorCode.EXPIRED_TOKEN;
+import static com._119.wepro.global.exception.errorcode.CommonErrorCode.INVALID_TOKEN;
+import static com._119.wepro.global.exception.errorcode.CommonErrorCode.REFRESH_DENIED;
+
+import com._119.wepro.auth.dto.request.AuthRequest.RefreshRequest;
+import com._119.wepro.auth.dto.response.TokenInfo;
+import com._119.wepro.auth.jwt.JwtTokenProvider;
+import com._119.wepro.global.exception.RestApiException;
+import com._119.wepro.global.exception.errorcode.UserErrorCode;
+import com._119.wepro.member.domain.Member;
+import com._119.wepro.member.domain.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RefreshService {
+
+  private final JwtTokenProvider jwtTokenProvider;
+  private final MemberRepository memberRepository;
+
+  public TokenInfo refresh(RefreshRequest request) {
+    String accessToken = request.getAccessToken();
+    String refreshToken = request.getRefreshToken();
+
+    if (!isTokenExpired(accessToken)) {
+      throw new RestApiException(REFRESH_DENIED);
+    }
+    String memberId = jwtTokenProvider.parseExpiredToken(accessToken)
+        .getSubject();
+    Member member = memberRepository.findById(Long.parseLong(memberId))
+        .orElseThrow(() -> new RestApiException(UserErrorCode.USER_NOT_FOUND));
+
+    validateRefreshToken(refreshToken, memberId);
+    return jwtTokenProvider.generateToken(Long.parseLong(memberId), member.getRole());
+  }
+
+  private boolean isTokenExpired(String accessToken) {
+    try {
+      jwtTokenProvider.validateToken(accessToken);
+      throw new RestApiException(REFRESH_DENIED);
+    } catch (RestApiException e) {
+      if (e.getErrorCode() == EXPIRED_TOKEN) {
+        return true;
+      }
+      throw e;
+    }
+  }
+
+  private void validateRefreshToken(String refreshToken, String memberId) {
+    String savedRefreshToken = jwtTokenProvider.getRefreshToken(memberId);
+    if (!refreshToken.equals(savedRefreshToken)) {
+      throw new RestApiException(INVALID_TOKEN);
+    }
+  }
+}

--- a/src/main/java/com/_119/wepro/auth/service/SignInService.java
+++ b/src/main/java/com/_119/wepro/auth/service/SignInService.java
@@ -1,0 +1,75 @@
+package com._119.wepro.auth.service;
+
+import static com._119.wepro.global.enums.Provider.APPLE;
+import static com._119.wepro.global.enums.Provider.KAKAO;
+
+import com._119.wepro.auth.dto.response.AuthResponse.SignInResponse;
+import com._119.wepro.auth.dto.response.TokenInfo;
+import com._119.wepro.global.enums.Provider;
+import com._119.wepro.global.enums.Role;
+import com._119.wepro.auth.jwt.JwtTokenProvider;
+import com._119.wepro.member.domain.Member;
+import com._119.wepro.member.domain.repository.MemberRepository;
+import com._119.wepro.auth.dto.request.AuthRequest.SignInRequest;
+import jakarta.transaction.Transactional;
+import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Service;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SignInService {
+
+  private final MemberRepository memberRepository;
+  private final JwtTokenProvider jwtTokenProvider;
+
+  private final Map<Provider, JwtDecoder> decoders = Map.of(
+      Provider.KAKAO, buildDecoder(KAKAO.getJwkSetUrl()),
+      Provider.APPLE, buildDecoder(APPLE.getJwkSetUrl()));
+
+  private JwtDecoder buildDecoder(String jwkUrl) {
+    return NimbusJwtDecoder.withJwkSetUri(jwkUrl).build();
+  }
+
+  @Transactional
+  public SignInResponse signIn(SignInRequest request) {
+    OidcUser oidcDecodePayload = socialLogin(request);
+
+    Member member = getOrSaveUser(request, oidcDecodePayload);
+    TokenInfo tokenInfo = jwtTokenProvider.generateToken(member.getId(), member.getRole());
+    boolean isNewMember = Role.GUEST == member.getRole();
+
+    return new SignInResponse(isNewMember, tokenInfo);
+  }
+
+
+  private Member getOrSaveUser(SignInRequest request, OidcUser oidcDecodePayload) {
+    Optional<Member> member = memberRepository.findByProviderAndProviderId(
+        request.getProvider(), oidcDecodePayload.getName());
+
+    return member.orElseGet(
+        () -> memberRepository.save(Member.of(request, oidcDecodePayload)));
+
+  }
+
+  private OidcUser socialLogin(SignInRequest request) {
+    Provider provider = request.getProvider();
+
+    Jwt jwt = decoders.get(provider).decode(request.getIdToken());
+    OidcIdToken oidcIdToken = new OidcIdToken(
+        jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(), jwt.getClaims());
+
+    return new DefaultOidcUser(null, oidcIdToken);
+//    throw new RestApiException(UNSUPPORTED_PROVIDER);
+  }
+}

--- a/src/main/java/com/_119/wepro/global/BaseEntity.java
+++ b/src/main/java/com/_119/wepro/global/BaseEntity.java
@@ -3,12 +3,11 @@ package com._119.wepro.global;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
-
-import java.time.LocalDateTime;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
@@ -18,10 +17,9 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public abstract class BaseEntity {
 
   @CreatedDate
-  @Column(nullable = false, updatable = false)
+  @Column(updatable = false)
   private LocalDateTime createdAt;
 
   @LastModifiedDate
-  @Column(nullable = false)
   private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/_119/wepro/global/config/FeignClientConfig.java
+++ b/src/main/java/com/_119/wepro/global/config/FeignClientConfig.java
@@ -4,7 +4,7 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableFeignClients(basePackages = "com._119.wepro.global.security.client")
+@EnableFeignClients(basePackages = "com._119.wepro.auth.client")
 public class FeignClientConfig {
 
 }

--- a/src/main/java/com/_119/wepro/global/config/FeignClientConfig.java
+++ b/src/main/java/com/_119/wepro/global/config/FeignClientConfig.java
@@ -1,0 +1,10 @@
+package com._119.wepro.global.config;
+
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients(basePackages = "com._119.wepro.global.security.client")
+public class FeignClientConfig {
+
+}

--- a/src/main/java/com/_119/wepro/global/config/RedisConfig.java
+++ b/src/main/java/com/_119/wepro/global/config/RedisConfig.java
@@ -1,18 +1,12 @@
 package com._119.wepro.global.config;
 
-import java.time.Duration;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.cache.RedisCacheConfiguration;
-import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -28,23 +22,6 @@ public class RedisConfig {
   @Bean
   public RedisConnectionFactory redisConnectionFactory() {
     return new LettuceConnectionFactory(host, port);
-  }
-
-  @Bean
-  public CacheManager oidcCacheManager(RedisConnectionFactory cf) {
-    RedisCacheConfiguration redisCacheConfiguration =
-        RedisCacheConfiguration.defaultCacheConfig()
-            .serializeKeysWith(
-                RedisSerializationContext.SerializationPair.fromSerializer(
-                    new StringRedisSerializer()))
-            .serializeValuesWith(
-                RedisSerializationContext.SerializationPair.fromSerializer(
-                    new GenericJackson2JsonRedisSerializer()))
-            .entryTtl(Duration.ofDays(7L));
-
-    return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf)
-        .cacheDefaults(redisCacheConfiguration)
-        .build();
   }
 
   @Bean

--- a/src/main/java/com/_119/wepro/global/config/RedisConfig.java
+++ b/src/main/java/com/_119/wepro/global/config/RedisConfig.java
@@ -1,0 +1,60 @@
+package com._119.wepro.global.config;
+
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+  @Value("${spring.data.redis.host}")
+  private String host;
+
+  @Value("${spring.data.redis.port}")
+  private int port;
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    return new LettuceConnectionFactory(host, port);
+  }
+
+  @Bean
+  public CacheManager oidcCacheManager(RedisConnectionFactory cf) {
+    RedisCacheConfiguration redisCacheConfiguration =
+        RedisCacheConfiguration.defaultCacheConfig()
+            .serializeKeysWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    new StringRedisSerializer()))
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    new GenericJackson2JsonRedisSerializer()))
+            .entryTtl(Duration.ofDays(7L));
+
+    return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf)
+        .cacheDefaults(redisCacheConfiguration)
+        .build();
+  }
+
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate() {
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+    return redisTemplate;
+  }
+}

--- a/src/main/java/com/_119/wepro/global/config/SecurityConfig.java
+++ b/src/main/java/com/_119/wepro/global/config/SecurityConfig.java
@@ -1,7 +1,7 @@
 package com._119.wepro.global.config;
 
-import com._119.wepro.global.security.jwt.JwtTokenProvider;
-import com._119.wepro.global.security.jwt.JwtTokenFilter;
+import com._119.wepro.auth.jwt.JwtTokenProvider;
+import com._119.wepro.auth.jwt.JwtTokenFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/_119/wepro/global/config/SecurityConfig.java
+++ b/src/main/java/com/_119/wepro/global/config/SecurityConfig.java
@@ -1,0 +1,48 @@
+package com._119.wepro.global.config;
+
+import com._119.wepro.global.security.jwt.JwtTokenProvider;
+import com._119.wepro.global.security.jwt.JwtTokenFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+  private final JwtTokenProvider jwtTokenProvider;
+
+  @Bean
+  public WebSecurityCustomizer webSecurityCustomizer() { // security를 적용하지 않을 리소스
+    return web -> web.ignoring()
+        .requestMatchers("/css/**", "/images/**", "/js/**", "/lib/**")
+        .requestMatchers("/", "/swagger-ui-custom.html", "/api-docs/**", "/swagger-ui/**", "swagger-ui.html", "/v3/api-docs/**")
+        .requestMatchers("/error", "/favicon.ico")
+        .requestMatchers("/auth/**", "/login/oauth2/code/**", "/login");
+  }
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http
+        .csrf(AbstractHttpConfigurer::disable)
+        .headers(header -> header.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
+        .sessionManagement(c -> c.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .authorizeHttpRequests(request -> request
+            .requestMatchers("/", "/auth/**", "/login/oauth2/code/**", "/login").permitAll()
+            .requestMatchers(HttpMethod.OPTIONS).permitAll()
+            .anyRequest().authenticated()
+        )
+        .addFilterBefore(new JwtTokenFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+    return http.build();
+  }
+}

--- a/src/main/java/com/_119/wepro/global/config/SecurityConfig.java
+++ b/src/main/java/com/_119/wepro/global/config/SecurityConfig.java
@@ -1,7 +1,8 @@
 package com._119.wepro.global.config;
 
-import com._119.wepro.auth.jwt.JwtTokenProvider;
+import com._119.wepro.auth.jwt.JwtTokenExceptionFilter;
 import com._119.wepro.auth.jwt.JwtTokenFilter;
+import com._119.wepro.auth.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -26,9 +27,10 @@ public class SecurityConfig {
   public WebSecurityCustomizer webSecurityCustomizer() { // security를 적용하지 않을 리소스
     return web -> web.ignoring()
         .requestMatchers("/css/**", "/images/**", "/js/**", "/lib/**")
-        .requestMatchers("/", "/swagger-ui-custom.html", "/api-docs/**", "/swagger-ui/**", "swagger-ui.html", "/v3/api-docs/**")
+        .requestMatchers("/", "/swagger-ui-custom.html", "/api-docs/**", "/swagger-ui/**",
+            "swagger-ui.html", "/v3/api-docs/**")
         .requestMatchers("/error", "/favicon.ico")
-        .requestMatchers("/auth/**", "/login/oauth2/code/**", "/login");
+        .requestMatchers("/auth/**", "/login/oauth2/code/**", "/login", "/refresh");
   }
 
   @Bean
@@ -42,7 +44,10 @@ public class SecurityConfig {
             .requestMatchers(HttpMethod.OPTIONS).permitAll()
             .anyRequest().authenticated()
         )
-        .addFilterBefore(new JwtTokenFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+        .logout(logout -> logout.disable())
+        .addFilterBefore(new JwtTokenFilter(jwtTokenProvider),
+            UsernamePasswordAuthenticationFilter.class)
+        .addFilterBefore(new JwtTokenExceptionFilter(), JwtTokenFilter.class);
     return http.build();
   }
 }

--- a/src/main/java/com/_119/wepro/global/enums/Provider.java
+++ b/src/main/java/com/_119/wepro/global/enums/Provider.java
@@ -1,0 +1,17 @@
+package com._119.wepro.global.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Provider {
+  KAKAO("https://kauth.kakao.com/.well-known/jwks.json"),
+  //TODO apple jwk set uri 세팅하기
+  APPLE("https://kauth.kakao.com/.well-known/jwks.json"),
+  ;
+
+  private final String jwkSetUrl;
+
+//  public static IdentityProvider of(){}
+}

--- a/src/main/java/com/_119/wepro/global/enums/Role.java
+++ b/src/main/java/com/_119/wepro/global/enums/Role.java
@@ -1,0 +1,5 @@
+package com._119.wepro.global.enums;
+
+public enum Role {
+  ADMIN, USER, GUEST
+}

--- a/src/main/java/com/_119/wepro/global/enums/Status.java
+++ b/src/main/java/com/_119/wepro/global/enums/Status.java
@@ -1,0 +1,5 @@
+package com._119.wepro.global.enums;
+
+public enum Status {
+  ACTIVE, INACTIVE
+}

--- a/src/main/java/com/_119/wepro/global/exception/errorcode/CommonErrorCode.java
+++ b/src/main/java/com/_119/wepro/global/exception/errorcode/CommonErrorCode.java
@@ -13,6 +13,7 @@ public enum CommonErrorCode implements ErrorCode {
   INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "Invalid token"),
   EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "Expired token"),
   NOT_EXIST_BEARER_SUFFIX(HttpStatus.UNAUTHORIZED, "Bearer prefix is missing."),
+  REFRESH_DENIED(HttpStatus.FORBIDDEN, "Refresh denied"),
   ;
 
   private final HttpStatus httpStatus;

--- a/src/main/java/com/_119/wepro/global/exception/errorcode/CommonErrorCode.java
+++ b/src/main/java/com/_119/wepro/global/exception/errorcode/CommonErrorCode.java
@@ -10,6 +10,9 @@ public enum CommonErrorCode implements ErrorCode {
   INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "Invalid parameter included"),
   RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "Resource not exists"),
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error"),
+  INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "Invalid token"),
+  EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "Expired token"),
+  NOT_EXIST_BEARER_SUFFIX(HttpStatus.UNAUTHORIZED, "Bearer prefix is missing."),
   ;
 
   private final HttpStatus httpStatus;

--- a/src/main/java/com/_119/wepro/global/exception/errorcode/UserErrorCode.java
+++ b/src/main/java/com/_119/wepro/global/exception/errorcode/UserErrorCode.java
@@ -10,6 +10,7 @@ public enum UserErrorCode implements ErrorCode {
 
   INACTIVE_USER(HttpStatus.FORBIDDEN, "User is inactive"),
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "User not found"),
+  UNSUPPORTED_PROVIDER(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "Unsupported provider"),
   ;
 
   private final HttpStatus httpStatus;

--- a/src/main/java/com/_119/wepro/global/util/RedisUtil.java
+++ b/src/main/java/com/_119/wepro/global/util/RedisUtil.java
@@ -1,0 +1,42 @@
+package com._119.wepro.global.util;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class RedisUtil {
+
+  private final RedisTemplate<String, String> redisTemplate;
+
+  public String getData(String key) {
+    ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+    return valueOperations.get(key);
+  }
+
+  public void setData(String key, String value) {
+    ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+    valueOperations.set(key, value);
+  }
+
+  public void setDataExpire(String key, String value, long duration) {
+    ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+    valueOperations.set(key, value, Duration.ofMillis(duration));
+  }
+
+  public void deleteData(String key) {
+    redisTemplate.delete(key);
+  }
+
+  public void expireValues(String key, int timeout) {
+    redisTemplate.expire(key, timeout, TimeUnit.MILLISECONDS);
+  }
+
+  public boolean existsData(String key) {
+    return redisTemplate.hasKey(key);
+  }
+}

--- a/src/main/java/com/_119/wepro/member/domain/Member.java
+++ b/src/main/java/com/_119/wepro/member/domain/Member.java
@@ -1,6 +1,5 @@
 package com._119.wepro.member.domain;
 
-import com._119.wepro.auth.dto.response.OIDCDecodePayload;
 import com._119.wepro.global.BaseEntity;
 import com._119.wepro.global.enums.Provider;
 import com._119.wepro.global.enums.Role;

--- a/src/main/java/com/_119/wepro/member/domain/Member.java
+++ b/src/main/java/com/_119/wepro/member/domain/Member.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.PostPersist;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -56,6 +57,12 @@ public class Member extends BaseEntity {
 
   private LocalDateTime inactivatedAt;
 
+  // 엔티티가 저장된 후 id로 태그를 생성합니다.
+  @PostPersist
+  public void generateTag() {
+    this.tag = this.id.toString();
+  }
+
   public static Member of(SignInRequest request, OidcUser oidcDecodePayload) {
     return Member.builder()
         .profile(oidcDecodePayload.getPicture())
@@ -64,8 +71,7 @@ public class Member extends BaseEntity {
         .role(Role.GUEST)
         .providerId(oidcDecodePayload.getName())
         .status(Status.ACTIVE)
-        //Todo 태그 생성하기
-//        .tag()
+        // 태그는 나중에 설정됩니다.
         .build();
   }
 }

--- a/src/main/java/com/_119/wepro/member/domain/Member.java
+++ b/src/main/java/com/_119/wepro/member/domain/Member.java
@@ -1,15 +1,25 @@
 package com._119.wepro.member.domain;
 
+import com._119.wepro.auth.dto.response.OIDCDecodePayload;
 import com._119.wepro.global.BaseEntity;
+import com._119.wepro.global.enums.Provider;
+import com._119.wepro.global.enums.Role;
+import com._119.wepro.global.enums.Status;
+import com._119.wepro.auth.dto.request.AuthRequest.SignInRequest;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 
 @Entity
 @Getter
@@ -22,5 +32,41 @@ public class Member extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  private String profile;
+
   private String name;
+
+  @Enumerated(value = EnumType.STRING)
+  @Column(length = 10, nullable = false)
+  private Provider provider;
+
+  @Column(length = 20, nullable = false)
+  private String providerId;
+
+  @Enumerated(value = EnumType.STRING)
+  @Column(length = 10, nullable = false)
+  private Status status;
+
+  @Enumerated(value = EnumType.STRING)
+  @Column(length = 10, nullable = false)
+  private Role role;
+
+  private String position;
+
+  private String tag;
+
+  private LocalDateTime inactivatedAt;
+
+  public static Member of(SignInRequest request, OidcUser oidcDecodePayload) {
+    return Member.builder()
+        .profile(oidcDecodePayload.getPicture())
+        .name(oidcDecodePayload.getNickName())
+        .provider(request.getProvider())
+        .role(Role.GUEST)
+        .providerId(oidcDecodePayload.getName())
+        .status(Status.ACTIVE)
+        //Todo 태그 생성하기
+//        .tag()
+        .build();
+  }
 }

--- a/src/main/java/com/_119/wepro/member/domain/Member.java
+++ b/src/main/java/com/_119/wepro/member/domain/Member.java
@@ -1,10 +1,10 @@
 package com._119.wepro.member.domain;
 
+import com._119.wepro.auth.dto.request.AuthRequest.SignInRequest;
 import com._119.wepro.global.BaseEntity;
 import com._119.wepro.global.enums.Provider;
 import com._119.wepro.global.enums.Role;
 import com._119.wepro.global.enums.Status;
-import com._119.wepro.auth.dto.request.AuthRequest.SignInRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -12,7 +12,9 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.PostPersist;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -26,6 +28,11 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@Table(
+    indexes = {
+        @Index(name = "idx_provider_id", columnList = "providerId")
+    }
+)
 public class Member extends BaseEntity {
 
   @Id

--- a/src/main/java/com/_119/wepro/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/_119/wepro/member/domain/repository/MemberRepository.java
@@ -1,10 +1,12 @@
 package com._119.wepro.member.domain.repository;
 
+import com._119.wepro.global.enums.Provider;
 import com._119.wepro.member.domain.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
-
+  Optional<Member> findByProviderAndProviderId(Provider provider, String providerId);
 }

--- a/src/main/java/com/_119/wepro/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/_119/wepro/member/domain/repository/MemberRepository.java
@@ -8,5 +8,8 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
   Optional<Member> findByProviderAndProviderId(Provider provider, String providerId);
+
+  Optional<Member> findByProviderId(String providerId);
 }

--- a/src/main/java/com/_119/wepro/member/presentation/MemberController.java
+++ b/src/main/java/com/_119/wepro/member/presentation/MemberController.java
@@ -1,0 +1,12 @@
+package com._119.wepro.member.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members")
+public class MemberController {
+
+}

--- a/src/main/java/com/_119/wepro/member/service/MemberService.java
+++ b/src/main/java/com/_119/wepro/member/service/MemberService.java
@@ -1,0 +1,10 @@
+package com._119.wepro.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,6 +14,22 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
-
-
-
+---
+spring:
+  data:
+    redis:
+      host: localhost
+      port: 6379
+---
+jwt:
+  secret: ${jwt.secret}
+---
+login:
+  uri: ${login.uri}
+---
+kakao:
+  client-id: ${kakao.client-id}
+  client-secret: ${kakao.client-secret}
+  redirect-uri: ${kakao.redirect-uri}
+  iss: https://kauth.kakao.com
+  authorization-uri: https://kauth.kakao.com/oauth/authorize

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,5 +15,10 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
 
-
-
+---
+kakao:
+  client-id: ${kakao.client-id}
+  client-secret: EN0ZGfmtay9f5WQzqaFtwAa6vh3YJ5F3
+  redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+  iss: https://kauth.kakao.com
+  authorization-uri: https://kauth.kakao.com/oauth/authorize

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,19 +14,17 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
----
-spring:
   data:
     redis:
       host: localhost
       port: 6379
----
+
 jwt:
   secret: ${jwt.secret}
----
+
 login:
   uri: ${login.uri}
----
+
 kakao:
   client-id: ${kakao.client-id}
   client-secret: ${kakao.client-secret}


### PR DESCRIPTION
### ✏️ Description

- JWT 관련 추가
- Redis 설정 추가(refresh token 관리)
- 로그인, 로그아웃, 토큰 재발급 api 구현
- 토큰 재발급: 만료된 accessToken과 refreshToken을 받아 두 토큰 모두 재발급
- 로그아웃: Redis에 저장된 refreshToken 삭제(클라이언트 측에서 저장하고 있던 accessToken 삭제)

</br>

### 🙏🏻 To Reviewers

- 보통 유저 인증 시, Subject 값으로 email을 많이 사용하는데 저희는 일단 Id를 사용하는 것을 구현했었어요. 근데 하다보니, Subject 값이 String 타입이어야 해서 Long 타입인 Id를 매번 toString(), Long.valueOf() 를 써서 타입을 매번 변경해야하더라구요..? 그래서 Subject 값으로 String 타입인 providerId(소셜 서버 ID)를 쓰는 걸로 바꿀까 생각이 들었는데 어떻게 생각하시나요?!
- 추가하거나 수정할 거 있으면 말씀해주세요!

</br>

### 💡 Issue Number

- Issue #11
